### PR TITLE
Fix: Optimize background noise for lower resolution displays

### DIFF
--- a/index.html
+++ b/index.html
@@ -374,6 +374,28 @@
             border-top: 1px solid rgba(125, 211, 252, 0.1);
         }
 
+        /* Responsive noise optimization for different display resolutions */
+        @media (max-resolution: 1dppx) {
+            /* Standard displays (1x) - reduce noise intensity */
+            .noise-overlay {
+                opacity: 0.3 !important;
+            }
+        }
+
+        @media (min-resolution: 2dppx) {
+            /* High DPI displays (Retina/2x+) - can handle more noise */
+            .noise-overlay {
+                opacity: 0.6 !important;
+            }
+        }
+
+        @media (min-resolution: 3dppx) {
+            /* Very high DPI displays - optimal noise */
+            .noise-overlay {
+                opacity: 0.7 !important;
+            }
+        }
+
         /* --- Responsive Adjustments --- */
         @media (max-width: 768px) {
             h1.name {
@@ -433,18 +455,18 @@
             <filter id="noiseFilter" x="0%" y="0%" width="100%" height="100%">
                 <feTurbulence
                     type="fractalNoise"
-                    baseFrequency="1.5"
-                    numOctaves="5"
+                    baseFrequency="0.9"
+                    numOctaves="4"
                     stitchTiles="stitch"/>
                 <feColorMatrix type="saturate" values="0"/>
                 <feComponentTransfer>
-                    <feFuncR type="linear" slope="0.5" intercept="0"/>
-                    <feFuncG type="linear" slope="0.5" intercept="0"/>
-                    <feFuncB type="linear" slope="0.5" intercept="0"/>
+                    <feFuncR type="linear" slope="0.4" intercept="0"/>
+                    <feFuncG type="linear" slope="0.4" intercept="0"/>
+                    <feFuncB type="linear" slope="0.4" intercept="0"/>
                 </feComponentTransfer>
             </filter>
         </defs>
-        <rect x="0" y="0" width="100%" height="100%" filter="url(#noiseFilter)" opacity="0.8"/>
+        <rect x="0" y="0" width="100%" height="100%" filter="url(#noiseFilter)" opacity="0.5"/>
     </svg>
     
     <div class="container">


### PR DESCRIPTION
- Reduce SVG turbulence baseFrequency from 1.5 to 0.9 for softer noise patterns
- Decrease numOctaves from 5 to 4 to reduce visual complexity
- Lower noise intensity by reducing slope values and overall opacity
- Add responsive media queries to optimize noise opacity based on display resolution:
  * Standard displays (1x): 30% opacity
  * High DPI displays (2x+): 60% opacity
  * Very high DPI displays (3x+): 70% opacity

This improves the appearance of background noise on standard monitors while maintaining the aesthetic effect on high-resolution displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)